### PR TITLE
Updated TranscribeDoc to handle duplicate names

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports.handler = async (event) => {
             console.debug(TranscribeDoc);
 
             try {
-                TranscribeDoc(indexerData, fileContext.fileName, folderId);
+                await TranscribeDoc(indexerData, fileContext.fileName, folderId);
             } catch (e) {
                 console.error(e);
             }


### PR DESCRIPTION
Changed TranscribeDoc to async so we can await the function in index.js (this may have been why the metadata cards were uploaded but not the transcribe doc). Added preflight check to check for duplicate file name and auto increment it to allow for copies.